### PR TITLE
feat(scripts): Add TOML linting workflow

### DIFF
--- a/scripts/submit-osmo-training.sh
+++ b/scripts/submit-osmo-training.sh
@@ -35,6 +35,7 @@ Options:
       --skip-register-checkpoint  Skip automatic model registration.
       --sleep-after-unpack VALUE  Provide a non-empty value to sleep post-unpack (ex. 7200 to sleep 2 hours).
   -s, --run-smoke-test    Enable the Azure connectivity smoke test before training.
+  -b, --backend BACKEND   Training backend: skrl (default), rsl_rl.
 
 Azure context overrides (resolved from Terraform outputs if not provided):
       --azure-subscription-id ID    Azure subscription ID
@@ -47,7 +48,7 @@ General:
 Environment overrides:
   TASK, NUM_ENVS, MAX_ITERATIONS, IMAGE, PAYLOAD_ROOT, RUN_AZURE_SMOKE_TEST
   CHECKPOINT_URI, CHECKPOINT_MODE, REGISTER_CHECKPOINT, SLEEP_AFTER_UNPACK
-  AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, AZUREML_WORKSPACE_NAME
+  TRAINING_BACKEND, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, AZUREML_WORKSPACE_NAME
 
 Additional arguments after -- are forwarded to osmo workflow submit.
 
@@ -84,6 +85,7 @@ CHECKPOINT_URI_VALUE=${CHECKPOINT_URI:-}
 CHECKPOINT_MODE_VALUE=${CHECKPOINT_MODE:-from-scratch}
 REGISTER_CHECKPOINT_VALUE=${REGISTER_CHECKPOINT:-}
 SLEEP_AFTER_UNPACK_VALUE=${SLEEP_AFTER_UNPACK:-}
+BACKEND_VALUE=${TRAINING_BACKEND:-skrl}
 
 # Three-tier value resolution: CLI > ENV > Terraform
 AZURE_SUBSCRIPTION_ID_VALUE="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
@@ -166,6 +168,10 @@ while [[ $# -gt 0 ]]; do
     -s|--run-smoke-test)
       RUN_AZURE_SMOKE_TEST_VALUE="1"
       shift
+      ;;
+    -b|--backend)
+      BACKEND_VALUE="$2"
+      shift 2
       ;;
     --sleep-after-unpack)
       SLEEP_AFTER_UNPACK_VALUE="$2"
@@ -263,6 +269,7 @@ submit_args=(
   "checkpoint_mode=$CHECKPOINT_MODE_VALUE"
   "register_checkpoint=$REGISTER_CHECKPOINT_VALUE"
   "sleep_after_unpack=$SLEEP_AFTER_UNPACK_VALUE"
+  "training_backend=$BACKEND_VALUE"
 )
 
 # Add Azure context from Terraform outputs

--- a/src/training/requirements.txt
+++ b/src/training/requirements.txt
@@ -9,5 +9,6 @@ packaging==23.0
 psutil>=5.9.0  # CPU, memory, disk metrics
 pynvml>=11.5.0  # NVIDIA GPU metrics (optional)
 pyperclip==1.8.0
-rsl-rl-lib==3.0.1
+rsl-rl-lib==3.1.2
 skrl>=1.4.3
+tensordict>=0.7.0  # Required by RSL-RL 3.x for TensorDict observations

--- a/src/training/scripts/launch_rsl_rl.py
+++ b/src/training/scripts/launch_rsl_rl.py
@@ -59,6 +59,18 @@ def _parse_args(argv: Sequence[str] | None) -> tuple[argparse.Namespace, list[st
         default=None,
         help="MLflow artifact URI for the checkpoint to materialize before training",
     )
+    parser.add_argument(
+        "--checkpoint-mode",
+        type=_optional_str,
+        default="from-scratch",
+        help="Checkpoint handling mode (fresh is treated as from-scratch)",
+    )
+    parser.add_argument(
+        "--register-checkpoint",
+        type=_optional_str,
+        default=None,
+        help="Register the final checkpoint as this Azure ML model name",
+    )
     args, remaining = parser.parse_known_args(argv)
     return args, list(remaining)
 

--- a/src/training/scripts/rsl_rl/train.py
+++ b/src/training/scripts/rsl_rl/train.py
@@ -133,6 +133,7 @@ if version.parse(installed_version) < version.parse(RSL_RL_VERSION):
 import gymnasium as gym
 import statistics
 import torch
+from tensordict import TensorDict
 from typing import Any, Optional
 
 import omni
@@ -153,7 +154,7 @@ from isaaclab.envs import (
 from isaaclab.utils.dict import print_dict
 from isaaclab.utils.io import dump_yaml
 
-from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import get_checkpoint_path
@@ -180,6 +181,66 @@ torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
 torch.backends.cudnn.deterministic = False
 torch.backends.cudnn.benchmark = False
+
+
+class RslRl3xCompatWrapper:
+    """Compatibility wrapper for RSL-RL 3.x TensorDict observation format.
+
+    RSL-RL 3.x expects observations to be a TensorDict with observation group keys.
+    Older Isaac Lab wrappers may return raw tensors or dicts. This wrapper ensures
+    get_observations() always returns a properly formatted TensorDict.
+    """
+
+    def __init__(self, env: RslRlVecEnvWrapper):
+        self._env = env
+        # Proxy all attributes to the underlying env
+        for attr in dir(env):
+            if not attr.startswith("_") and attr not in ("get_observations", "step", "reset"):
+                try:
+                    setattr(self, attr, getattr(env, attr))
+                except AttributeError:
+                    pass
+
+    def __getattr__(self, name: str):
+        return getattr(self._env, name)
+
+    def _ensure_tensordict(self, obs) -> TensorDict:
+        """Convert observations to TensorDict format expected by RSL-RL 3.x."""
+        if isinstance(obs, TensorDict):
+            return obs
+        if isinstance(obs, dict):
+            return TensorDict(obs, batch_size=[self._env.num_envs])
+        if isinstance(obs, torch.Tensor):
+            # Single tensor - wrap as 'policy' observation group
+            return TensorDict({"policy": obs}, batch_size=[self._env.num_envs])
+        if isinstance(obs, tuple):
+            # Tuple (obs_tensor, extras) from older wrappers
+            obs_data = obs[0]
+            if isinstance(obs_data, dict):
+                return TensorDict(obs_data, batch_size=[self._env.num_envs])
+            return TensorDict({"policy": obs_data}, batch_size=[self._env.num_envs])
+        raise TypeError(f"Unsupported observation type: {type(obs)}")
+
+    def get_observations(self) -> TensorDict:
+        """Get observations in RSL-RL 3.x TensorDict format."""
+        obs = self._env.get_observations()
+        return self._ensure_tensordict(obs)
+
+    def step(self, actions: torch.Tensor):
+        """Step the environment and return observations as TensorDict."""
+        result = self._env.step(actions)
+        # result is (obs, rew, dones, extras) - ensure obs is TensorDict
+        obs, rew, dones, extras = result
+        obs_td = self._ensure_tensordict(obs)
+        return obs_td, rew, dones, extras
+
+    def reset(self):
+        """Reset the environment and return observations as TensorDict."""
+        result = self._env.reset()
+        if isinstance(result, tuple):
+            obs, extras = result
+            return self._ensure_tensordict(obs), extras
+        return self._ensure_tensordict(result), {}
 
 
 def _is_primary_rank(args_cli: argparse.Namespace, app_launcher: AppLauncher) -> bool:
@@ -492,7 +553,7 @@ def _create_enhanced_save(
 @hydra_task_config(args_cli.task, args_cli.agent)
 def main(
     env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg,
-    agent_cfg: RslRlBaseRunnerCfg,
+    agent_cfg: RslRlOnPolicyRunnerCfg,
 ):
     """Train with RSL-RL agent."""
     is_primary_process = _is_primary_rank(args_cli, app_launcher)
@@ -626,13 +687,25 @@ def main(
 
     # wrap around environment for rsl-rl
     env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+    # Apply RSL-RL 3.x compatibility wrapper to ensure TensorDict observations
+    env = RslRl3xCompatWrapper(env)
 
-    if agent_cfg.class_name == "OnPolicyRunner":
-        runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
-    elif agent_cfg.class_name == "DistillationRunner":
-        runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    # Convert config to dict and ensure RSL-RL 3.x required fields are present
+    agent_cfg_dict = agent_cfg.to_dict()
+    # RSL-RL 3.x requires 'obs_groups' with a 'policy' key mapping to observation group names
+    if "obs_groups" not in agent_cfg_dict or agent_cfg_dict["obs_groups"] is None:
+        agent_cfg_dict["obs_groups"] = {"policy": ["policy"]}
+    elif "policy" not in agent_cfg_dict["obs_groups"]:
+        agent_cfg_dict["obs_groups"]["policy"] = ["policy"]
+    # RSL-RL 3.x requires 'class_name' for runner selection
+    runner_class_name = agent_cfg_dict.get("class_name", "OnPolicyRunner")
+
+    if runner_class_name == "OnPolicyRunner":
+        runner = OnPolicyRunner(env, agent_cfg_dict, log_dir=log_dir, device=agent_cfg.device)
+    elif runner_class_name == "DistillationRunner":
+        runner = DistillationRunner(env, agent_cfg_dict, log_dir=log_dir, device=agent_cfg.device)
     else:
-        raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+        raise ValueError(f"Unsupported runner class: {runner_class_name}")
     runner.add_git_repo_to_log(__file__)
     if resume_path:
         print(f"[INFO]: Loading model checkpoint from: {resume_path}")

--- a/workflows/osmo/train.yaml
+++ b/workflows/osmo/train.yaml
@@ -34,6 +34,7 @@ workflow:
         CHECKPOINT_URI: "{{ checkpoint_uri }}"
         CHECKPOINT_MODE: "{{ checkpoint_mode }}"
         REGISTER_CHECKPOINT: "{{ register_checkpoint }}"
+        TRAINING_BACKEND: "{{ training_backend }}"
       files:
         - path: /tmp/entry.sh
           contents: |
@@ -99,4 +100,5 @@ default-values:
   checkpoint_uri: ""
   checkpoint_mode: "from-scratch"
   register_checkpoint: ""
+  training_backend: "skrl"
 


### PR DESCRIPTION
# RSL_RL Backend for OSMO

PR Soundtrack: [Little Brother - Altitudes](https://www.youtube.com/watch?v=ixLUsttBgTY)

## Summary

This pull request introduces support for selecting the training backend (between `skrl` and `rsl_rl`) for the OSMO training workflow scripts, and updates the RSL-RL integration to be compatible with RSL-RL 3.x, including proper handling of the new TensorDict observation format. It also updates dependencies and improves environment variable and argument handling for consistency.

**Training backend selection:**

* Added a new `--backend`/`-b` CLI argument and `TRAINING_BACKEND` environment variable to `scripts/submit-osmo-training.sh`, allowing users to select the training backend (`skrl` or `rsl_rl`). This value is passed through the workflow and made available in training jobs. [[1]](diffhunk://#diff-4f9657d351004bbbf0b81237b33e1c92666d58f550b21690c93751dbd581b748R38) [[2]](diffhunk://#diff-4f9657d351004bbbf0b81237b33e1c92666d58f550b21690c93751dbd581b748L50-R51) [[3]](diffhunk://#diff-4f9657d351004bbbf0b81237b33e1c92666d58f550b21690c93751dbd581b748R88) [[4]](diffhunk://#diff-4f9657d351004bbbf0b81237b33e1c92666d58f550b21690c93751dbd581b748R172-R175) [[5]](diffhunk://#diff-4f9657d351004bbbf0b81237b33e1c92666d58f550b21690c93751dbd581b748R272) [[6]](diffhunk://#diff-35b7682186207613905ef5351acc1dfa1631988e336534f0f91c6da8cf9095ffR37) [[7]](diffhunk://#diff-35b7682186207613905ef5351acc1dfa1631988e336534f0f91c6da8cf9095ffR103)

**RSL-RL 3.x compatibility:**

* Updated the RSL-RL dependency to version 3.1.2 and added `tensordict` as a required dependency.
* Introduced a `RslRl3xCompatWrapper` in `train.py` to ensure all environment observations conform to the TensorDict format required by RSL-RL 3.x, supporting backward compatibility with older wrappers. [[1]](diffhunk://#diff-c345b829be43d7f57e9c7ed67d5eeb3003625c39428c650b278bd38008c8fcaeR136) [[2]](diffhunk://#diff-c345b829be43d7f57e9c7ed67d5eeb3003625c39428c650b278bd38008c8fcaeR186-R245)
* Updated the runner configuration and instantiation logic to ensure required fields (like `obs_groups` and `class_name`) are present and correct for RSL-RL 3.x. [[1]](diffhunk://#diff-c345b829be43d7f57e9c7ed67d5eeb3003625c39428c650b278bd38008c8fcaeL156-R157) [[2]](diffhunk://#diff-c345b829be43d7f57e9c7ed67d5eeb3003625c39428c650b278bd38008c8fcaeL495-R556) [[3]](diffhunk://#diff-c345b829be43d7f57e9c7ed67d5eeb3003625c39428c650b278bd38008c8fcaeL629-R708)

**Argument and environment improvements:**

* Added support for `--checkpoint-mode` and `--register-checkpoint` arguments in `launch_rsl_rl.py` for improved checkpoint handling.
* add RslRl3xCompatWrapper for TensorDict observation format in RSL-RL 3.x
* add --backend/-b flag to select training backend (skrl, rsl_rl)
* upgrade rsl-rl-lib to 3.1.2 with tensordict dependency
* pass training_backend parameter through OSMO workflow template

🤖 - Generated by Copilot