### PR TITLE
feat(scripts): Add infrastructure scanning tools

### DIFF
--- a/deploy/001-iac/modules/platform/postgresql.tf
+++ b/deploy/001-iac/modules/platform/postgresql.tf
@@ -98,6 +98,12 @@ resource "azurerm_postgresql_flexible_server" "main" {
     }
   }
 
+  // When the zone is set to null Azure will pick an available zone which then could cause
+  // terraform to try and change the zone, this results in an error on multiple deployments
+  lifecycle {
+    ignore_changes = [zone]
+  }
+
   depends_on = [azurerm_private_dns_zone_virtual_network_link.postgresql]
 }
 


### PR DESCRIPTION
# fix(deploy): ignore changes to zone in PostgreSQL flexible server lifecycle

Added a lifecycle block to the PostgreSQL flexible server resource to ignore changes to the zone attribute, preventing deployment errors on subsequent Terraform applies.

- **fix**(_platform_): Added `lifecycle { ignore_changes = [zone] }` block to `azurerm_postgresql_flexible_server.main` resource
  - When zone is set to null, Azure automatically selects an available zone, which caused Terraform to detect drift and attempt zone changes on subsequent deployments

🔧 - Generated by Copilot