### PR TITLE
feat(deploy): support workload identity updates from OSMO

### DIFF
--- a/deploy/002-setup/03-deploy-osmo-control-plane.sh
+++ b/deploy/002-setup/03-deploy-osmo-control-plane.sh
@@ -243,7 +243,7 @@ helm_args=("${base_helm_args[@]}" -f "$service_values" --set "services.postgres.
 [[ -n "$osmo_identity_client_id" ]] && helm_args+=(-f "$service_identity_values" --set "serviceAccount.annotations.azure\.workload\.identity/client-id=$osmo_identity_client_id")
 
 if [[ "$use_acr" == "true" ]]; then
-  helm upgrade -i service "oci://${acr_login_server}/helm/osmo" "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
+  helm upgrade -i service "oci://${acr_login_server}/helm/service" "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
 else
   helm upgrade -i service osmo/service "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
 fi
@@ -264,7 +264,7 @@ info "Deploying osmo/web-ui..."
 helm_args=("${base_helm_args[@]}" -f "$ui_values")
 
 if [[ "$use_acr" == "true" ]]; then
-  helm upgrade -i ui "oci://${acr_login_server}/helm/ui" "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
+  helm upgrade -i ui "oci://${acr_login_server}/helm/web-ui" "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
 else
   helm upgrade -i ui osmo/web-ui "${helm_args[@]}" --wait --timeout "$TIMEOUT_DEPLOY"
 fi

--- a/deploy/002-setup/config/workflow-config-workload-identity.template.json
+++ b/deploy/002-setup/config/workflow-config-workload-identity.template.json
@@ -1,7 +1,6 @@
 {
   "workflow_data": {
     "credential": {
-      "access_key_id": "${STORAGE_ACCESS_KEY_ID}",
       "endpoint": "${WORKFLOW_DATA_ENDPOINT}",
       "region": "${AZURE_REGION}"
     },
@@ -9,14 +8,12 @@
   },
   "workflow_log": {
     "credential": {
-      "access_key_id": "${STORAGE_ACCESS_KEY_ID}",
       "endpoint": "${WORKFLOW_LOG_ENDPOINT}",
       "region": "${AZURE_REGION}"
     }
   },
   "workflow_app": {
     "credential": {
-      "access_key_id": "${STORAGE_ACCESS_KEY_ID}",
       "endpoint": "${WORKFLOW_APP_ENDPOINT}",
       "region": "${AZURE_REGION}"
     }
@@ -30,8 +27,6 @@
       "ghcr.io",
       "${ACR_LOGIN_SERVER}"
     ],
-    "disable_data_validation": [
-      "azure"
-    ]
+    "disable_data_validation": []
   }
 }


### PR DESCRIPTION
# feat: support identity updates from OSMO

This PR updates Helm chart OCI registry paths for OSMO components and removes legacy credential fields from the workload identity configuration template.

**Requires** https://github.com/NVIDIA/OSMO/pull/141 to be merged.

- **fix**(_deploy_): Corrected Helm chart paths for OSMO service and web-ui components
  - Changed `oci://${acr_login_server}/helm/osmo` to `oci://${acr_login_server}/helm/service`
  - Changed `oci://${acr_login_server}/helm/ui` to `oci://${acr_login_server}/helm/web-ui`

- **fix**(_config_): Removed `access_key_id` from workflow-config-workload-identity.template.json
  - Eliminated from `workflow_data`, `workflow_log`, and `workflow_app` credential blocks
  - Cleared `disable_data_validation` array (previously contained `"azure"`)

- **chore**(_scripts_): Changed workflow submission command from `osmo` to `osmo-dev` in submit-osmo-dataset-training.sh

- **chore**(_automation_): Commented out Azure managed identity connection in Start-AzureResources.ps1

🔧 - Generated by Copilot
