### PR TITLE
docs(src): add docstrings to training utils context module

### DIFF
--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -1462,6 +1462,7 @@ sandboxed
 anymal
 autolog
 azureml
+cartpole
 chkpt
 cudnn
 DDPG

--- a/src/training/utils/context.py
+++ b/src/training/utils/context.py
@@ -1,4 +1,13 @@
-"""Azure ML bootstrap helpers for IsaacLab training entrypoints."""
+"""Azure ML bootstrap helpers for IsaacLab training entrypoints.
+
+Provides ``bootstrap_azure_ml`` to initialize an Azure ML workspace
+connection, configure MLflow tracking, and optionally set up Azure
+Blob Storage for checkpoint uploads.
+
+Required dependencies: ``azure-ai-ml``, ``azure-identity``, ``mlflow``.
+Optional: ``azure-storage-blob`` (for checkpoint uploads via
+``AzureStorageContext``).
+"""
 
 from __future__ import annotations
 
@@ -25,10 +34,38 @@ class AzureConfigError(RuntimeError):
 
 @dataclass(frozen=True)
 class AzureStorageContext:
+    """Azure Blob Storage client wrapper for checkpoint and artifact uploads.
+
+    Wraps a ``BlobServiceClient`` with convenience methods for uploading
+    single files, batches of files, and training checkpoints. All uploads
+    overwrite existing blobs with the same name.
+
+    Attributes:
+        blob_client: Authenticated Azure Blob Storage service client.
+        container_name: Target container for all upload operations.
+    """
+
     blob_client: "BlobServiceClient"
     container_name: str
 
     def upload_file(self, *, local_path: str, blob_name: str) -> str:
+        """Upload a single file to Azure Blob Storage.
+
+        Reads the file at *local_path* and uploads it to the configured
+        container under *blob_name*. Overwrites any existing blob with
+        the same name.
+
+        Args:
+            local_path: Absolute or relative path to the local file.
+            blob_name: Destination blob name within the container.
+
+        Returns:
+            The blob name of the uploaded file.
+
+        Raises:
+            FileNotFoundError: When *local_path* does not point to an
+                existing file.
+        """
         file_path = Path(local_path)
         if not file_path.is_file():
             raise FileNotFoundError(f"Checkpoint file not found: {local_path}")
@@ -44,11 +81,16 @@ class AzureStorageContext:
     def upload_files_batch(self, files: list[tuple[str, str]]) -> list[str]:
         """Upload multiple files in parallel using Azure SDK.
 
+        Operates on a best-effort basis. Individual upload failures are
+        caught and reported via printed warnings rather than raised.
+        Failed files are omitted from the return value.
+
         Args:
-            files: List of (local_path, blob_name) tuples
+            files: List of (local_path, blob_name) tuples.
 
         Returns:
-            List of successfully uploaded blob names
+            List of successfully uploaded blob names. May be shorter
+            than *files* when individual uploads fail.
         """
         if not files:
             return []
@@ -91,6 +133,26 @@ class AzureStorageContext:
         model_name: str,
         step: Optional[int] = None,
     ) -> str:
+        """Upload a training checkpoint with an auto-generated blob name.
+
+        Constructs a blob path under ``checkpoints/{model_name}/`` using a
+        UTC timestamp and optional training step number. The file extension
+        from *local_path* is preserved.
+
+        Blob name format: ``checkpoints/{model_name}/{YYYYMMDD_HHMMSS}[_step_{N}]{ext}``
+
+        Args:
+            local_path: Path to the local checkpoint file.
+            model_name: Model identifier used as a directory prefix.
+            step: Optional training step number appended to the blob name.
+
+        Returns:
+            The generated blob name of the uploaded checkpoint.
+
+        Raises:
+            FileNotFoundError: When *local_path* does not point to an
+                existing file (raised by ``upload_file``).
+        """
         timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
         file_path = Path(local_path)
         suffix = file_path.suffix or ""
@@ -101,6 +163,20 @@ class AzureStorageContext:
 
 @dataclass(frozen=True)
 class AzureMLContext:
+    """Azure ML workspace connection context.
+
+    Holds the authenticated ``MLClient``, MLflow tracking URI, and an
+    optional ``AzureStorageContext`` for checkpoint uploads. Created by
+    ``bootstrap_azure_ml``.
+
+    Attributes:
+        client: Authenticated Azure ML workspace client.
+        tracking_uri: MLflow tracking URI for the workspace.
+        workspace_name: Name of the connected Azure ML workspace.
+        storage: Optional storage context for blob uploads, or ``None``
+            when ``AZURE_STORAGE_ACCOUNT_NAME`` is not set.
+    """
+
     client: MLClient
     tracking_uri: str
     workspace_name: str
@@ -108,11 +184,42 @@ class AzureMLContext:
 
 
 def _optional_env(name: str) -> Optional[str]:
+    """Return the value of an environment variable, or ``None`` when unset or empty.
+
+    Args:
+        name: Environment variable name to look up.
+
+    Returns:
+        Non-empty string value, or ``None`` when the variable is unset
+        or contains an empty string.
+    """
     value = os.environ.get(name)
     return value or None
 
 
 def _build_storage_context(credential: Any) -> Optional[AzureStorageContext]:
+    """Build an Azure Blob Storage context if storage is configured.
+
+    Creates a ``BlobServiceClient`` using the provided credential and
+    the account URL derived from ``AZURE_STORAGE_ACCOUNT_NAME``. Creates
+    the target container if it does not exist.
+
+    Returns ``None`` when ``AZURE_STORAGE_ACCOUNT_NAME`` is not set,
+    allowing callers to treat storage as an optional feature.
+
+    Args:
+        credential: Azure credential instance for authentication.
+
+    Returns:
+        Configured ``AzureStorageContext``, or ``None`` when storage
+        is not configured.
+
+    Raises:
+        AzureConfigError: When ``azure-storage-blob`` is not installed
+            but ``AZURE_STORAGE_ACCOUNT_NAME`` is set.
+        AzureConfigError: When container initialization fails due to
+            an Azure service error.
+    """
     account_name = _optional_env("AZURE_STORAGE_ACCOUNT_NAME")
     if not account_name:
         return None
@@ -144,6 +251,17 @@ def _build_storage_context(credential: Any) -> Optional[AzureStorageContext]:
 
 
 def _build_credential() -> DefaultAzureCredential:
+    """Build an Azure credential with managed identity support.
+
+    Configures ``DefaultAzureCredential`` with optional managed identity
+    client ID from ``AZURE_CLIENT_ID`` or ``DEFAULT_IDENTITY_CLIENT_ID``
+    (fallback). Set ``AZURE_EXCLUDE_MANAGED_IDENTITY=true`` to skip the
+    managed identity credential when running on Azure VMs during local
+    development.
+
+    Returns:
+        Configured ``DefaultAzureCredential`` instance.
+    """
     managed_identity_client_id = os.environ.get("AZURE_CLIENT_ID")
     default_identity_client_id = os.environ.get("DEFAULT_IDENTITY_CLIENT_ID")
 
@@ -165,6 +283,51 @@ def bootstrap_azure_ml(
     *,
     experiment_name: str,
 ) -> AzureMLContext:
+    """Initialize an Azure ML workspace connection and configure MLflow.
+
+    Reads required configuration from environment variables, creates an
+    authenticated ML client, configures MLflow tracking, and optionally
+    initializes Azure Blob Storage for checkpoint uploads.
+
+    Required environment variables:
+        - ``AZURE_SUBSCRIPTION_ID``: Azure subscription identifier.
+        - ``AZURE_RESOURCE_GROUP``: Resource group containing the workspace.
+        - ``AZUREML_WORKSPACE_NAME``: Azure ML workspace name.
+
+    Optional environment variables:
+        - ``AZURE_STORAGE_ACCOUNT_NAME``: Enables checkpoint storage when set.
+        - ``AZURE_STORAGE_CONTAINER_NAME``: Blob container name
+          (default: ``"isaaclab-training-logs"``).
+        - ``AZURE_CLIENT_ID``: Managed identity client ID.
+        - ``DEFAULT_IDENTITY_CLIENT_ID``: Fallback for ``AZURE_CLIENT_ID``.
+        - ``AZURE_EXCLUDE_MANAGED_IDENTITY``: Set to ``"true"`` to skip
+          managed identity credential.
+        - ``AZURE_AUTHORITY_HOST``: Azure AD authority host override.
+
+    Args:
+        experiment_name: MLflow experiment name to set as active.
+
+    Returns:
+        Fully initialized ``AzureMLContext`` with workspace client,
+        tracking URI, and optional storage context.
+
+    Raises:
+        AzureConfigError: When a required environment variable is missing
+            or empty.
+        AzureConfigError: When the Azure ML client cannot be created.
+        AzureConfigError: When the workspace cannot be accessed.
+        AzureConfigError: When the workspace does not expose an MLflow
+            tracking URI.
+        AzureConfigError: When MLflow tracking configuration fails.
+
+    Example:
+        >>> ctx = bootstrap_azure_ml(experiment_name="isaaclab-cartpole")
+        >>> ctx.client.workspaces.get(ctx.workspace_name)
+        >>> if ctx.storage:
+        ...     ctx.storage.upload_checkpoint(
+        ...         local_path="model.pt", model_name="cartpole"
+        ...     )
+    """
     subscription_id = require_env("AZURE_SUBSCRIPTION_ID", error_type=AzureConfigError)
     resource_group = require_env("AZURE_RESOURCE_GROUP", error_type=AzureConfigError)
     workspace_name = require_env("AZUREML_WORKSPACE_NAME", error_type=AzureConfigError)


### PR DESCRIPTION
## Description

Added comprehensive Google-style docstrings to all public symbols and nontrivial private helpers in `src/training/utils/context.py`. Docstrings cover class-level documentation with attributes, method signatures with args/returns/raises, environment variable references, and usage examples.

- docs(src): added Google-style docstrings to all 10 symbols in `src/training/utils/context.py` including `AzureConfigError`, `AzureStorageContext`, `AzureMLContext`, `_optional_env`, `_build_storage_context`, `_build_credential`, and `bootstrap_azure_ml`
- docs(src): expanded module-level docstring with dependency requirements and purpose summary
- chore(settings): added "cartpole" to `.cspell/general-technical.txt` custom dictionary to support docstring examples

Closes #74

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [x] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [ ] I have performed a self-review
- [ ] Documentation updated as needed
- [ ] No new linting warnings introduced