### PR TITLE
chore(scripts): add Pester test runner and fix test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:ps": "pwsh -File scripts/linting/Invoke-PSScriptAnalyzer.ps1",
     "lint:links": "pwsh -File scripts/linting/Invoke-LinkLanguageCheck.ps1",
     "lint:all": "npm run lint:md && npm run lint:ps && npm run lint:links",
-    "format:tables": "markdown-table-formatter \"**/*.md\""
+    "format:tables": "markdown-table-formatter \"**/*.md\"",
+    "test:ps": "pwsh -File ./scripts/tests/Invoke-PesterTests.ps1"
   },
   "devDependencies": {
     "cspell": "9.4.0",

--- a/scripts/tests/Invoke-PesterTests.ps1
+++ b/scripts/tests/Invoke-PesterTests.ps1
@@ -1,0 +1,69 @@
+#!/usr/bin/env pwsh
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: MIT
+#
+# Invoke-PesterTests.ps1
+#
+# Purpose: Thin runner wrapping pester.config.ps1 for local and CI execution
+# Author: Robotics-AI Team
+#
+
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Runs Pester tests for the repository.
+.DESCRIPTION
+    Wraps pester.config.ps1 to build a Pester 5.x configuration and invokes
+    Invoke-Pester. Provides a convenient local entry point alongside the
+    pester-tests.yml workflow which calls pester.config.ps1 directly.
+.PARAMETER CI
+    Enables CI mode: exit on failure, NUnit XML output, GitHub Actions annotations.
+.PARAMETER CodeCoverage
+    Enables JaCoCo code coverage collection.
+.PARAMETER TestPath
+    Paths to search for test files. Defaults to the scripts/tests directory.
+.EXAMPLE
+    ./Invoke-PesterTests.ps1
+.EXAMPLE
+    ./Invoke-PesterTests.ps1 -CI -CodeCoverage
+.EXAMPLE
+    ./Invoke-PesterTests.ps1 -TestPath ./security
+#>
+[CmdletBinding()]
+param(
+    [switch]$CI,
+    [switch]$CodeCoverage,
+    [string[]]$TestPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$configParams = @{}
+if ($CI.IsPresent) { $configParams['CI'] = $true }
+if ($CodeCoverage.IsPresent) { $configParams['CodeCoverage'] = $true }
+if ($TestPath) { $configParams['TestPath'] = $TestPath }
+
+$config = & "$PSScriptRoot/pester.config.ps1" @configParams
+$result = Invoke-Pester -Configuration $config
+
+# Write step summary in CI environments when CIHelpers is available
+if ($CI.IsPresent) {
+    $ciHelpersPath = Join-Path $PSScriptRoot '../lib/Modules/CIHelpers.psm1'
+    if (Test-Path $ciHelpersPath) {
+        Import-Module $ciHelpersPath -Force
+        if (Get-Command -Name Write-CIStepSummary -ErrorAction SilentlyContinue) {
+            $summary = @"
+## Pester Test Results
+
+| Metric  | Count                    |
+|---------|--------------------------|
+| Run     | $($result.TotalCount)    |
+| Passed  | $($result.PassedCount)   |
+| Failed  | $($result.FailedCount)   |
+| Skipped | $($result.SkippedCount)  |
+"@
+            Write-CIStepSummary -Content $summary
+        }
+    }
+}

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,121 @@
+---
+title: PowerShell Testing
+description: Testing patterns, directory structure, and execution guide for Pester-based PowerShell tests
+---
+
+PowerShell tests use [Pester 5.7.1](https://pester.dev/) with a split configuration and execution model. The `pester.config.ps1` file builds a `[PesterConfiguration]` object, and `Invoke-PesterTests.ps1` invokes `Invoke-Pester` with that configuration.
+
+## 🏗️ Directory Structure
+
+```text
+scripts/tests/
+├── Invoke-PesterTests.ps1              # Runner wrapper for local and CI execution
+├── pester.config.ps1                   # Pester 5.x configuration generator
+├── Fixtures/                           # Static test data organized by domain
+│   ├── Npm/                            # package.json fixtures
+│   ├── Security/                       # Checksum and download fixtures
+│   └── Workflows/                      # GitHub Actions workflow fixtures
+├── Mocks/                              # Reusable mock modules
+│   └── GitMocks.psm1                   # Git CLI and CI environment mocks
+└── security/                           # Security-related test files
+    ├── SecurityHelpers.Tests.ps1
+    └── Test-DependencyPinning.Tests.ps1
+```
+
+## 🚀 Running Tests
+
+### Local Execution
+
+```powershell
+./scripts/tests/Invoke-PesterTests.ps1
+```
+
+Run with code coverage:
+
+```powershell
+./scripts/tests/Invoke-PesterTests.ps1 -CodeCoverage
+```
+
+Run tests in a specific subdirectory:
+
+```powershell
+./scripts/tests/Invoke-PesterTests.ps1 -TestPath ./scripts/tests/security
+```
+
+### npm Script
+
+```bash
+npm run test:ps
+```
+
+### CI Mode
+
+CI mode enables NUnit XML output, non-zero exit on failure, and GitHub Actions annotations:
+
+```powershell
+./scripts/tests/Invoke-PesterTests.ps1 -CI -CodeCoverage
+```
+
+## ⚙️ Conventions
+
+### Test File Naming
+
+Test files use `.Tests.ps1` extension and mirror source layout:
+
+| Source Path                                   | Test Path                                                 |
+|-----------------------------------------------|-----------------------------------------------------------|
+| `scripts/security/Test-DependencyPinning.ps1` | `scripts/tests/security/Test-DependencyPinning.Tests.ps1` |
+| `scripts/linting/Check-Something.ps1`         | `scripts/tests/linting/Check-Something.Tests.ps1`         |
+
+Test subdirectories mirror the `scripts/` source layout. Create matching directories under `scripts/tests/` as you add tests for new source areas.
+
+### Tags
+
+Pester tags control which tests run in different contexts:
+
+| Tag           | Purpose                                               | Default Behavior |
+|---------------|-------------------------------------------------------|------------------|
+| `Unit`        | Standard unit tests                                   | Included         |
+| `Integration` | Tests requiring live services or network access       | Excluded         |
+| `Slow`        | Long-running tests unsuitable for quick feedback loop | Excluded         |
+
+Apply tags at the `Describe` block level:
+
+```powershell
+Describe 'Test-SHAPinning' -Tag 'Unit' {
+    # ...
+}
+```
+
+### Fixtures
+
+Place static test data under `Fixtures/` in domain-specific subdirectories.
+
+Reference fixtures using `$PSScriptRoot` relative paths in `BeforeAll`:
+
+```powershell
+BeforeAll {
+    $script:FixturesPath = Join-Path $PSScriptRoot '../Fixtures/Workflows'
+}
+```
+
+### Mocks
+
+Reusable mock modules live under `Mocks/`. Import them in `BeforeAll` with `-Force` to ensure a clean state:
+
+```powershell
+BeforeAll {
+    $mockPath = Join-Path $PSScriptRoot '../Mocks/GitMocks.psm1'
+    Import-Module $mockPath -Force
+}
+```
+
+`GitMocks.psm1` provides helpers for saving, restoring, and simulating CI environment variables across GitHub Actions and Azure DevOps contexts.
+
+### Code Coverage
+
+Coverage targets scripts under `linting/`, `security/`, and `lib/` directories. The threshold is 80%.
+
+Enable coverage locally with `-CodeCoverage` on the runner or `pester.config.ps1`. CI workflows produce JaCoCo XML at `logs/coverage.xml` for artifact upload.
+
+Files matching `*.Tests.ps1` are excluded from coverage analysis automatically.

--- a/scripts/tests/pester.config.ps1
+++ b/scripts/tests/pester.config.ps1
@@ -4,8 +4,8 @@
 #
 # pester.config.ps1
 #
-# Purpose: Pester 5.x configuration for HVE-Core PowerShell testing
-# Author: HVE Core Team
+# Purpose: Pester 5.x configuration for PowerShell testing
+# Author: Robotics-AI Team
 #
 
 [CmdletBinding()]
@@ -40,7 +40,7 @@ $configuration.Output.CILogLevel = 'Error'
 $configuration.TestResult.Enabled = $CI.IsPresent
 $configuration.TestResult.OutputFormat = 'NUnitXml'
 $configuration.TestResult.OutputPath = Join-Path $PSScriptRoot '../../logs/pester-results.xml'
-$configuration.TestResult.TestSuiteName = 'HVE-Core-PowerShell-Tests'
+$configuration.TestResult.TestSuiteName = 'Robotics-RefArch-PowerShell-Tests'
 
 # Code coverage configuration
 if ($CodeCoverage.IsPresent) {
@@ -50,7 +50,7 @@ if ($CodeCoverage.IsPresent) {
 
     # Resolve coverage paths explicitly - Join-Path with wildcards returns literal paths without file system expansion in Pester configuration
     $scriptRoot = Split-Path $PSScriptRoot -Parent
-    $coverageDirs = @('linting', 'security', 'dev-tools', 'lib', 'extension')
+    $coverageDirs = @('linting', 'security', 'lib')
 
     $coveragePaths = $coverageDirs | ForEach-Object {
         Get-ChildItem -Path (Join-Path $scriptRoot $_) -Include '*.ps1', '*.psm1' -Recurse -File -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Description

Added `Invoke-PesterTests.ps1` as a thin runner wrapper for local and CI execution of Pester tests, fixed suite metadata and coverage directories in `pester.config.ps1`, and documented the testing directory structure in a new README.

Closes #55

- Added `Invoke-PesterTests.ps1` wrapping `pester.config.ps1` with `-CI`, `-CodeCoverage`, and `-TestPath` passthrough, including CI step summary output via `CIHelpers`
- Fixed `pester.config.ps1` suite name to `Robotics-RefArch-PowerShell-Tests`, author to `Robotics-AI Team`, and coverage directories to `linting`, `security`, `lib`
- Added `test:ps` npm script for convenient local test execution
- Added `scripts/tests/README.md` documenting directory structure, conventions, fixtures, mocks, tags, and code coverage

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [x] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] Documentation updated in this PR

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

🧪 - Generated by Copilot