### PR TITLE
feat(scripts): add verified download utility with hash checking

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -121,7 +121,7 @@ jobs:
           # Filter to specific test files if running changed-files-only
           $testPaths = '${{ steps.changed-files.outputs.test-paths }}'
           if ($testPaths -and '${{ inputs.changed-files-only }}' -eq 'true') {
-            $configParams['TestPaths'] = $testPaths -split ','
+            $configParams['TestPath'] = $testPaths -split ','
           }
 
           try {

--- a/scripts/tests/lib/Get-VerifiedDownload.Tests.ps1
+++ b/scripts/tests/lib/Get-VerifiedDownload.Tests.ps1
@@ -369,7 +369,7 @@ Describe 'Invoke-VerifiedDownload' {
                 Set-Content -Path $OutFile -Value 'bad content' -NoNewline
             }
             Mock Get-FileHashValue { return 'MISMATCHHASH23456789012345678901234567890123456789012345678901' }
-            Mock Remove-Item { } -Verifiable
+            Mock Remove-Item { Microsoft.PowerShell.Management\Remove-Item -Path $Path -ErrorAction SilentlyContinue } -Verifiable
 
             { Invoke-VerifiedDownload `
                     -Url $script:testUrl `


### PR DESCRIPTION
## Description

Closes #54

Adds `Get-VerifiedDownload.ps1`, a hash-verified download utility supporting SHA-256, SHA-384, and SHA-512 checksum validation with optional archive extraction for `.zip`, `.tar.gz`, `.tgz`, and `.tar` formats. Ported from hve-core with bug fixes applied from review feedback.

- feat(scripts): add `Get-VerifiedDownload.ps1` with pure-function architecture for testability and an I/O wrapper for orchestration
- feat(scripts): add Pester test suite with 39 tests covering hash computation, path resolution, cache-hit logic, download flow, extraction, and error handling
- fix(scripts): persist archive at target path before extraction so the file remains on disk after `Expand-Archive` or `tar` runs
- fix(scripts): add extraction logic to the cache-hit early-return path when the `-Extract` flag is set

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

🔧 - Generated by Copilot