### PR TITLE
build(build): add OS matrix and -CI flag to Pester tests workflow

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -130,6 +130,7 @@ jobs:
 
           try {
             $config = & scripts/tests/pester.config.ps1 -CI @configParams
+            $config.Run.Exit = $false
             $result = Invoke-Pester -Configuration $config
 
             if ($result.FailedCount -gt 0) {


### PR DESCRIPTION
## Description

Add OS matrix and `-CI` flag to the reusable Pester tests workflow.

* Expand the `pester` job to run across `ubuntu-latest`, `windows-latest`, and `macos-latest` via a strategy matrix with `fail-fast: false`.
* Pass the `-CI` flag to `pester.config.ps1` so test configuration can detect CI environments.
* Suffix artifact names with `${{ matrix.os }}` to prevent upload collisions across matrix legs.
* Restrict coverage upload and threshold steps to `ubuntu-latest` only to avoid duplicate coverage reports.

Closes #62

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced