### PR TITLE
fix(build): resolve release-please draft race condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,6 @@ jobs:
 
   # Automated release PR management via release-please
   release-please:
-    if: "${{ !startsWith(github.event.head_commit.message, 'chore(main): release') }}"
     needs:
       - spell-check
       - markdown-lint
@@ -119,11 +118,6 @@ jobs:
       minor: ${{ steps.release.outputs.minor }}
       patch: ${{ steps.release.outputs.patch }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e  # v2.10.2
-        with:
-          egress-policy: audit
-
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.0.0
@@ -138,6 +132,37 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: release-please-manifest.json
+          # On release commits, skip PR creation to prevent bogus PRs
+          # from draft release lazy tag timing. Release commits have zero
+          # unreleased changes so skipping loses nothing. The tag is
+          # created in the next step, ensuring subsequent runs find it.
+          skip-github-pull-request: ${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main)') }}
+
+      # Workaround: release-please with "draft": true uses lazy tag
+      # creation. The git tag is not materialized until the release is
+      # published. Without the tag, release-please cannot find the draft
+      # on subsequent runs, breaking version anchoring and causing bogus
+      # changelog entries. The skip-github-pull-request conditional above
+      # prevents PR creation on release commits (zero unreleased changes),
+      # and this step creates the tag so subsequent runs find the release.
+      # Replace both workarounds with "force-tag-creation": true in
+      # release-please-config.json once release-please-action ships a
+      # version that includes googleapis/release-please#2627.
+      - name: Create git tag for draft release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          TAG="${{ steps.release.outputs.tag_name }}"
+          REPO="${{ github.repository }}"
+          if ! gh api "/repos/$REPO/git/refs/tags/$TAG" --silent 2>/dev/null; then
+            gh api "/repos/$REPO/git/refs" \
+              -f "ref=refs/tags/$TAG" \
+              -f "sha=${{ github.sha }}"
+            echo "Created git tag $TAG -> ${{ github.sha }}"
+          else
+            echo "Git tag $TAG already exists"
+          fi
 
   # Promote draft release to published
   publish-release:
@@ -152,11 +177,6 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e  # v2.10.2
-        with:
-          egress-policy: audit
-
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.0.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "draft": true,
   "release-search-depth": 800,
   "commit-search-depth": 1000,
   "packages": {
     ".": {
       "release-type": "node",
+      "draft": true,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
# Pull Request

## Description

Resolves the root cause of PR #173 generating a bogus changelog that included all previous release-please PRs. The `"draft": true` config causes release-please to use lazy tag creation — the git tag isn't materialized until the draft release is published. Without the tag, subsequent release-please runs scan the entire commit history, producing bloated changelogs.

Mirrors the proven mitigation from microsoft/hve-core PR #560.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Changes

- **release-please-config.json**: Move `"draft": true` from top level to package level (matches hve-core structure)
- **.github/workflows/main.yml**:
  - Remove job-level `if` guard that skipped release-please entirely on release commits
  - Add `skip-github-pull-request` input conditioned on release commits (prevents bogus PRs without skipping tag/release creation)
  - Add explicit git tag creation step after release-please runs (ensures the tag exists for subsequent runs)
  - Remove Harden Runner steps from release-please and publish-release jobs

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced