### PR TITLE
fix(build): remove invalid double cast on JaCoCo counter array

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           if (Test-Path logs/coverage.xml) {
             [xml]$coverage = Get-Content logs/coverage.xml
-            $lineRate = [double]$coverage.report.counter |
+            $lineRate = $coverage.report.counter |
               Where-Object { $_.type -eq 'LINE' } |
               ForEach-Object {
                 $missed = [int]$_.missed


### PR DESCRIPTION
## Description

Removed a `[double]` cast that was applied to the entire `$coverage.report.counter` array before the pipeline could filter it to the `LINE` counter type. JaCoCo XML reports contain multiple `<counter>` elements (LINE, BRANCH, etc.), so the cast on `System.Object[]` raised a conversion error and broke the Coverage Threshold Check step on every CI run.

- fix(build): removed premature `[double]` cast from the `$coverage.report.counter` pipeline expression in the Coverage Threshold Check step of the Pester Tests workflow

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

<!-- Describe testing. Check applicable items -->

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced