### PR TITLE
fix(scripts): wrap array returns in Markdown-Link-Check to prevent strict mode failure

### DIFF
--- a/scripts/linting/Markdown-Link-Check.ps1
+++ b/scripts/linting/Markdown-Link-Check.ps1
@@ -99,7 +99,7 @@ function Get-MarkdownTarget {
                 }
             }
         }
-        return ($targets | Sort-Object -Unique)
+        return @($targets | Sort-Object -Unique)
     }
 
     Write-Verbose "Searching for git-tracked markdown files..."
@@ -145,7 +145,7 @@ function Get-MarkdownTarget {
     }
 
     Write-Verbose "Found $($targets.Count) git-tracked markdown files"
-    return ($targets | Sort-Object -Unique)
+    return @($targets | Sort-Object -Unique)
 }
 
 function Invoke-MarkdownLinkCheckCore {
@@ -160,7 +160,7 @@ function Invoke-MarkdownLinkCheckCore {
     $repoRootPath = Split-Path -Path $scriptRootParent -Parent
     $repoRoot = Resolve-Path -LiteralPath $repoRootPath
     $config = Resolve-Path -LiteralPath $ConfigPath -ErrorAction Stop
-    $filesToCheck = Get-MarkdownTarget -InputPath $Path
+    $filesToCheck = @(Get-MarkdownTarget -InputPath $Path)
 
     if (-not $filesToCheck -or $filesToCheck.Count -eq 0) {
         Write-Error 'No markdown files were found to validate.'


### PR DESCRIPTION
## Description

Wrapped `Get-MarkdownTarget` return values and the caller assignment in `@()` array subexpressions to prevent `Sort-Object -Unique` from unwrapping single-element arrays into bare strings. Under `Set-StrictMode -Version Latest`, accessing `.Count` on a bare string throws a `PropertyNotFoundException`, which caused the markdown link check CI step to fail when only one `.md` file was in scope (e.g., the release-please PR that only changes `CHANGELOG.md`).

- Wrapped the non-git fallback `return` in `@()` to preserve array type
- Wrapped the git-tracked `return` in `@()` to preserve array type
- Wrapped the `$filesToCheck` assignment in `@()` to prevent single-element unwrap at the call site

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [x] Confirmed `.Count` property access succeeds on single-element returns under `Set-StrictMode -Version Latest`
- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

🐛 - Generated by Copilot