### PR TITLE
feat(scripts): add PowerShell dev environment bootstrap script

### DIFF
--- a/setup-dev.ps1
+++ b/setup-dev.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: MIT
 
@@ -99,11 +100,15 @@ $UvVersion = '0.7.12'
 
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     Write-Info "Installing uv package manager v$UvVersion..."
-    if ($IsWindows) {
-        Invoke-RestMethod "https://astral.sh/uv/$UvVersion/install.ps1" | Invoke-Expression
+    $uvInstaller = Join-Path ([System.IO.Path]::GetTempPath()) 'uv-install.ps1'
+    try {
+        Invoke-WebRequest -Uri "https://astral.sh/uv/$UvVersion/install.ps1" -OutFile $uvInstaller -UseBasicParsing
+        & $uvInstaller
     }
-    else {
-        & bash -c "curl -LsSf https://astral.sh/uv/$UvVersion/install.sh | sh"
+    finally {
+        Remove-Item $uvInstaller -Force -ErrorAction SilentlyContinue
+    }
+    if (-not $IsWindows) {
         $env:PATH = "$HOME/.local/bin:$HOME/.cargo/bin:$env:PATH"
     }
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Description

Closes #334

Added *setup-dev.ps1* as a cross-platform PowerShell 7+ companion to the existing `setup-dev.sh`. The script automates full developer environment setup — tool verification, UV package manager installation, Python virtual environment creation, IsaacLab cloning, and hve-core detection.

- Verified prerequisite tools (`az`, `terraform`, `kubectl`, `helm`, `jq`) via **Assert-Tools** helper
- Installed `uv` v0.7.12 with platform-specific install paths
- Created Python venv from `.python-version` and synced dependencies via `uv sync` / `uv lock`
- Cloned `isaac-sim/IsaacLab` into `external/IsaacLab` for IntelliSense support
- Checked for adjacent `hve-core` directory with guidance when missing
- Supported `-DisableVenv` switch to skip virtual environment creation
- Displayed devcontainer recommendation banner and post-setup next steps

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- `setup-dev.ps1` — new root-level PowerShell bootstrap script

## Testing Performed

- [x] PSScriptAnalyzer reports no errors (warnings only: `Write-Host` and `Invoke-Expression` usage, expected for an interactive setup script)
- [x] Script parses and validates without syntax errors

## Documentation Impact

- [x] No documentation changes needed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced